### PR TITLE
Fixed misspelling of "-tmpl" as "-tpl"

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Windows
 
 ```
 # Avoid BOM in config file
-> .\uchess.exe -tpl | set-content uchess.json -Encoding Ascii
+> .\uchess.exe -tmpl | set-content uchess.json -Encoding Ascii
 ```
 
 Run **uchess** on the config.


### PR DESCRIPTION
The `-tmpl` flag was misspelled in the example.