### PR TITLE
fix: implement quit command fixes #9

### DIFF
--- a/pkg/cmd.go
+++ b/pkg/cmd.go
@@ -145,6 +145,10 @@ func hint(gs *GameState) string {
 	return strings.Repeat(" ", 80)
 }
 
+func quit(gs *GameState) string {
+	return "quit"
+}
+
 // ProcessCmd processes a move request or command
 func ProcessCmd(cmd string, gs *GameState) (string, *chess.Game) {
 	cmd = strings.TrimSpace(cmd)
@@ -171,6 +175,8 @@ func ProcessCmd(cmd string, gs *GameState) (string, *chess.Game) {
 		// Process a move string
 	case "hint":
 		return hint(gs), gs.Game
+	case "quit":
+		return quit(gs), gs.Game
 	default:
 		if err := gs.Game.MoveStr(cmd); err != nil {
 			return "\u26A0 Illegal. Try again.", gs.Game


### PR DESCRIPTION
The quit command is not implemented although it is documented. cmd/uchess does handle Ctrl-C to exit currently.

Add a pkg/cmd ProcessCmd() case handler for the command "quit". Add a private function pkg/cmd quit() where additional game state shutdown housekeeping could be processed, e.g. autosave on quit if desired. Currenly the function only returns the msg "quit", mirroring the hint command.

Add a cmd/uchess Interact() handler for the msg "quit". On quit, ask for confirmation with Y or y. Exit process on confirm, without saving as is currently documented. Move the internal function Interact().quit() to a public function cmd/uchess Quit() where additional process shutdown housekeeping could be implemented. Currently the function only calls gamestate S.Fini() and os.Exit(0) the process with return code.